### PR TITLE
Support modules as configuration files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 - Go through each configuration value and sets it on the application (via `app.set(name, value)`).
   - If the value is a valid environment variable (e.v. `NODE_ENV`), use its value instead
   - If the value start with `./` or `../` turn it it an absolute path relative to the configuration file path
+- Both `default` and `<env>` configurations can be modules which provide their computed settings with `module.exports = {...}` and a `.js` file suffix. See `test/config/testing.js` for an example.  
+All rules listed above apply for `.js` modules.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
     "mocha": "NODE_ENV=testing mocha test/ --compilers js:babel-core/register",
-    "test": "npm run jshint && npm run mocha && nsp check"
+    "test": "npm run jshint 2>/dev/null && npm run mocha && nsp check"
   },
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
     "mocha": "NODE_ENV=testing mocha test/ --compilers js:babel-core/register",
-    "test": "npm run jshint 2>/dev/null && npm run mocha && nsp check"
+    "test": "npm run jshint && npm run mocha && nsp check"
   },
   "directories": {
     "lib": "lib"

--- a/src/index.js
+++ b/src/index.js
@@ -40,15 +40,15 @@ export default module.exports = function (root, configFolder = 'config', separat
       return result;
     };
 
-    const config = convert(require(path.join(root, configFolder, 'default.json')));
+    const config = convert(require(path.join(root, configFolder, 'default')));
 
     debug(`Initializing configuration for ${env} environment`);
 
     // Dev is our default development. For everything else extend the default
     if(env !== 'development') {
-      const envConfig = path.join(root, configFolder, `${env}.json`);
+      const envConfig = path.join(root, configFolder, env);
       // We can use sync here since configuration only happens once at startup
-      if(fs.existsSync(envConfig)) {
+      if(fs.existsSync(`${envConfig}.js`) || fs.existsSync(`${envConfig}.json`)) {
         Object.assign(config, convert(require(envConfig)));
       } else {
         debug(`Configuration file for ${env} environment not found at ${envConfig}`);

--- a/test/config/testing.js
+++ b/test/config/testing.js
@@ -1,0 +1,17 @@
+// feathers-configuration pulls in default and <env> settings files using
+// Node's `require()`.
+// Node require() looks first for <filename>.js,
+// and if not found, it will check for <filename>.json
+//
+// This configuration file has `.js` suffix, and must provide
+// a `module.exports` containing the configuration properties.
+
+var derivedSetting = 'Hello World';
+var derivedEnvironment = 'NODE_ENV';
+
+module.exports = {
+  from: 'testing',
+  testEnvironment: 'NODE_ENV',
+  derived: derivedSetting,
+  derivedEnvironment: derivedEnvironment
+};

--- a/test/config/testing.json
+++ b/test/config/testing.json
@@ -1,4 +1,0 @@
-{
-  "from": "testing",
-  "test_environment": "NODE_ENV"
-}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,20 +6,28 @@ import plugin from '../src';
 describe('feathers-configuration', () => {
   const app = feathers().configure(plugin(__dirname));
 
-  it('initialized app with default.json data', () =>
+  it('initialized app with default data', () =>
     assert.equal(app.get('port'), 3030)
   );
 
-  it('initialized with <env>.json', () =>
+  it('initialized with <env>', () =>
     assert.equal(app.get('from'), 'testing')
+  );
+
+  it('initialized with <env> derived data module', () =>
+    assert.equal(app.get('derived'), 'Hello World')
   );
 
   it('initialized property with environment variable', () =>
     assert.equal(app.get('environment'), 'testing')
   );
 
-  it('initialized property with environment variable from <env>.json', () =>
-    assert.equal(app.get('test_environment'), 'testing')
+  it('initialized property with environment variable from <env>', () =>
+    assert.equal(app.get('testEnvironment'), 'testing')
+  );
+
+  it('initialized property with derived environment variable from <env> module', () =>
+    assert.equal(app.get('derivedEnvironment'), 'testing')
   );
 
   it('uses an escape character', () =>


### PR DESCRIPTION
Node require('filename') w/out the file extension will look for either `filename.js` first, or if not found, `filename.json`.
This commit expands feathers-configuration to support default or <env> settings files
which can generate derived configuration properties.
All support for path expansion and environment variables remains intact.

Closes #12 