### PR TITLE
Support `null` values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default module.exports = function (root, configFolder = 'config', deep = 
       Object.keys(current).forEach(name => {
         let value = current[name];
 
-        if(typeof value === 'object') {
+        if(typeof value === 'object' && value !== null) {
           value = convert(value);
         }
 

--- a/test/config/default.json
+++ b/test/config/default.json
@@ -6,5 +6,6 @@
   "from": "default",
   "deeply": { "nested": { "env": "NODE_ENV" } },
   "array": ["one", "two", "three"],
-  "deep": { "base": false }
+  "deep": { "base": false },
+  "nullish": null
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,4 +52,8 @@ describe('feathers-configuration', () => {
       merge: true
     })
   );
+
+  it('supports null value', () => {
+    assert.strictEqual(app.get('nullish'), null);
+  });
 });


### PR DESCRIPTION
Hello!

I noticed that if I had a configuration like this:

``` json
{
  "host": "localhost",
  "port": 9001,
  "cert": null
}
```

I would get an error because of the `null` value:

```
/home/kenan/code/_/node_modules/feathers-configuration/lib/index.js:42
      Object.keys(current).forEach(function (name) {
             ^

TypeError: Cannot convert undefined or null to object
    at convert (/home/kenan/code/_/node_modules/feathers-configuration/lib/index.js:42:14)
    at /home/kenan/code/_/node_modules/feathers-configuration/lib/index.js:46:19
    at Array.forEach (native)
    at convert (/home/kenan/code/_/node_modules/feathers-configuration/lib/index.js:42:28)
    at EventEmitter.<anonymous> (/home/kenan/code/_/node_modules/feathers-configuration/lib/index.js:68:18)
    at EventEmitter.configure (/home/kenan/code/_/node_modules/feathers/lib/application.js:138:8)
    at Object.<anonymous> (/home/kenan/code/_/src/app.js:19:5)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/kenan/code/_/src/index.js:8:13)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
```

This is because `typeof null === 'object'`, thus this module attempts to read the keys of this "object", which don't exist. This patch solves this issue by ensuring that `value` is not `null`. Alternatively I could amend the patch to use [`lodash.isplainobject`](https://www.npmjs.com/package/lodash.isplainobject),  if that is desired.