### PR TITLE
implement node-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@
 
 ## About
 
-`feathers-configuration` allows you to load default and environment specific JSON configuration files and environment variables and set them on your application. Here is what it does:
+This release of `feathers-configuration` simply acts as a wrapped around [node-config](https://github.com/lorenwest/node-config).
 
-- Given a root and configuration path load a `default.json` in that path
-- When the `NODE_ENV` is not `development`, also try to load `<NODE_ENV>.json` in that path and merge both configurations
-- Go through each configuration value and sets it on the application (via `app.set(name, value)`).
-  - If the value is a valid environment variable (e.v. `NODE_ENV`), use its value instead
-  - If the value start with `./` or `../` turn it it an absolute path relative to the configuration file path
-- Both `default` and `<env>` configurations can be modules which provide their computed settings with `module.exports = {...}` and a `.js` file suffix. See `test/config/testing.js` for an example.  
-All rules listed above apply for `.js` modules.
+By default this implementation will look in `config/*` for `default.json`.
+
+As per the [config docs](https://github.com/lorenwest/node-config/wiki/Configuration-Files) this is highly configurable.
+
+Future releases will also include adapters for external configuration storage.
 
 ## Usage
 
@@ -25,7 +23,7 @@ import feathers from 'feathers';
 import configuration from 'feathers-configuration';
 
 // Use the current folder as the root and look configuration up in `settings`
-let app = feathers().configure(configuration(__dirname, 'settings'))
+let app = feathers().configure()
 ```
 
 ## Example
@@ -55,18 +53,22 @@ In `config/production.js` we are going to use environment variables (e.g. set by
 
 Now it can be used in our `app.js` like this:
 
-```
+```js
 import feathers from 'feathers';
 import configuration from 'feathers-configuration';
 
+let conf = configuration();
+
 let app = feathers()
-  .configure(configuration(__dirname));
+  .configure(conf);
 
 console.log(app.get('frontend'));
 console.log(app.get('host'));
 console.log(app.get('port'));
 console.log(app.get('mongodb'));
 console.log(app.get('templates'));
+console.log(conf());
+
 ```
 
 If you now run
@@ -80,7 +82,14 @@ node app
 // -> path/to/templates
 ```
 
-Or with a different environment and variables:
+Or via custom environment variables by setting them in `config/custom-environment-variables.json`:
+
+```js
+{
+  "port": "PORT",
+  "mongodb": "MONGOHQ_URL"
+}
+```
 
 ```
 PORT=8080 MONGOHQ_URL=mongodb://localhost:27017/production NODE_ENV=production node app
@@ -90,6 +99,8 @@ PORT=8080 MONGOHQ_URL=mongodb://localhost:27017/production NODE_ENV=production n
 // -> mongodb://localhost:27017/production
 // -> path/to/templates
 ```
+
+You can also override these variables with arguments. Read more about how with [node-config](https://github.com/lorenwest/node-config)
 
 ## License
 

--- a/example/app.js
+++ b/example/app.js
@@ -1,11 +1,14 @@
 import feathers from 'feathers';
 import configuration from '../src';
 
+let conf = configuration();
+
 let app = feathers()
-  .configure(configuration(__dirname));
+  .configure(conf);
 
 console.log(app.get('frontend'));
 console.log(app.get('host'));
 console.log(app.get('port'));
 console.log(app.get('mongodb'));
 console.log(app.get('templates'));
+console.log(conf());

--- a/example/config/custom-environment-variables.json
+++ b/example/config/custom-environment-variables.json
@@ -1,0 +1,4 @@
+{
+  "port": "PORT",
+  "mongodb": "MONGOHQ_URL"
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "compile": "rm -rf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
-    "mocha": "NODE_ENV=testing mocha test/ --compilers js:babel-core/register",
+    "mocha": "NODE_CONFIG_DIR=./test/config/ NODE_ENV=testing mocha test/ --compilers js:babel-core/register",
     "test": "npm run jshint && npm run mocha && nsp check"
   },
   "directories": {
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "deep-assign": "^2.0.0"
+    "config": "^1.21.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.4",

--- a/test/config/custom-environment-variables.json
+++ b/test/config/custom-environment-variables.json
@@ -1,0 +1,4 @@
+{
+  "port": "PORT",
+  "mongodb": "MONGOHQ_URL"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ import { join } from 'path';
 import plugin from '../src';
 
 describe('feathers-configuration', () => {
-  const app = feathers().configure(plugin(__dirname));
+  const app = feathers().configure(plugin());
 
   it('initialized app with default data', () =>
     assert.equal(app.get('port'), 3030)


### PR DESCRIPTION
## overview
This is a _**mostly**_ backwards compatible implementation of [node-config](https://github.com/lorenwest/node-config).

It closes #25 and should be able to merge separately from #26 if we think we want to release it without all the other goodies described in that epic.

## change log
- constructor arguments will no longer set path, folder or disable deep assignment
- custom configs are now set the [node-config way](https://github.com/lorenwest/node-config/wiki/Environment-Variables#custom-environment-variables) using `NODE_CONFIG_DIR` and `NODE_ENV`
- you can now override your configuration with with cli arguments as well
- you can call the `configuration()` constructor directly to get the full config object

## release
Since there is still a pretty major breaking API change within the constructor I think we should release this as 0.4 or 1.0 in Auk and then release #26 as next stable during Buzzard.
